### PR TITLE
fix string in python scripts

### DIFF
--- a/benchmarks/tests/python2.py
+++ b/benchmarks/tests/python2.py
@@ -27,7 +27,7 @@ million = 1000000
 objects = []
 
 for i in range(1, 10 * million):
-    obj = SomeObject('random')
+    obj = SomeObject('tere')
     objects.append(obj)
 
 

--- a/benchmarks/tests/python3.py
+++ b/benchmarks/tests/python3.py
@@ -27,7 +27,7 @@ million = 1000000
 objects = []
 
 for i in range(1, 10 * million):
-    obj = SomeObject('random')
+    obj = SomeObject('tere')
     objects.append(obj)
 
 


### PR DESCRIPTION
Python scripts should use the same 'tere' string in their tests